### PR TITLE
Two bug fixes

### DIFF
--- a/Form1.vb
+++ b/Form1.vb
@@ -1364,7 +1364,7 @@ Public Class Form1
             svcRequest = svcRequest & "barcode=" & InputBox.Text
         Else
             If UseRestfulApi.Checked Then
-                fixedBarcode = Replace(InputBox.Text, "+", "%2B")
+                fixedBarcode = Replace(Trim(InputBox.Text), "+", "%2B")
                 svcRequest = apiURL.Text & apiMethod.Text.Replace("{item_barcode}", fixedBarcode) & "&apikey=" & apiKey.Text
             End If
         End If

--- a/Form1.vb
+++ b/Form1.vb
@@ -1802,6 +1802,8 @@ Public Class Form1
         Dim endname As String = ""
         Dim sp As Integer = 0
         Dim ep As Integer = 0
+        Dim currentSelectionFont As Font
+
         Try
             With RichTextBox1
                 While True
@@ -1823,12 +1825,17 @@ Public Class Form1
                     nextend = .Find(">", nextclose, RichTextBoxFinds.MatchCase)
                     endname = Mid$(.Text, nextclose + 1, nextend - nextclose + 1)
                     If tagname = endname.Replace("/", "") Then
+                        'For RichTextBox.SelectionFont Property:
+                        'If the current text selection has more than one font specified, the property SelectionFont is null,
+                        'so we use a variable to hold the current one SelectionFont.
+                        currentSelectionFont = RichTextBox1.SelectionFont
+
                         sp = tagend + 1
                         ep = nextclose - 1
                         .SelectionStart = sp
                         .SelectionLength = ep - sp + 1
                         .SelectionColor = Color.Black
-                        .SelectionFont = New Font(Me.RichTextBox1.SelectionFont, FontStyle.Bold)
+                        .SelectionFont = New Font(currentSelectionFont, FontStyle.Bold)
                     End If
                     tagstart = tagstart + 1
                 End While


### PR DESCRIPTION
Hello, thank you for your contribution, this software is very useful. 

We encountered two problems when using SpineOMatic:

- If there is a leading or trailing space in the barcode, the xml file cannot be retrieved.
- When formatting a xml in the rich text box under the 'Current XML' tab, if the current selected text has more than one font, then the property SelectionFont is null (or nothing), which will cause a null reference exception.
![NullReferenceException](https://user-images.githubusercontent.com/4425929/59904408-008e9580-9436-11e9-964c-cdcf5175da8f.png)

We have solved these two problems. Maybe this can help other users.
Thank you.